### PR TITLE
PAINT-319: Add TapTargetView license notice

### DIFF
--- a/licenses.html
+++ b/licenses.html
@@ -153,6 +153,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 </p>
 
+<p><strong>TapTargetView</strong><br/><a href="https://github.com/KeepSafe/TapTargetView" target="_blank">&lt;https://github.com/KeepSafe/TapTargetView&gt;</a><br/>
+Copyright 2016 Keepsafe Software Inc.<br/>
+<br/>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at<br/>
+<br/>
+<a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a><br/>
+<br/>
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+</p>
+
 <!-- Catrobat license details bottom: -->
 
 <p>Check back here from time-to-time, because we are always trying to improve our licenses.</p>


### PR DESCRIPTION
Pocket Paint uses https://github.com/KeepSafe/TapTargetView as a dependency.
This pull request adds their license notice.